### PR TITLE
Benchmarks and some optimizations

### DIFF
--- a/benc.cabal
+++ b/benc.cabal
@@ -60,6 +60,26 @@ test-suite benc-test
     default-language: Haskell2010
     type:             exitcode-stdio-1.0
 
+benchmark benc-bench
+    import:           warnings
+
+    build-depends:
+        base
+      , benc
+      , deepseq
+      , tasty
+      , tasty-bench
+      , tasty-hunit
+      , bytestring
+      , containers
+      , text
+      , vector
+
+    hs-source-dirs:   bench
+    main-is:          Bench.hs
+    default-language: Haskell2010
+    type:             exitcode-stdio-1.0
+
 benchmark benc-compare
     import:           warnings
 

--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -1,0 +1,222 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Main (main) where
+
+import Test.Tasty.Bench
+
+import Data.Bits
+import Data.Int
+import Data.Semigroup
+import Data.Word
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Char8 as BC
+import qualified Data.ByteString.Builder as BB
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.Map.Strict as M
+import qualified Data.Text as T
+import qualified Data.Vector as V
+
+import qualified Data.Bencode.Decode as D
+import qualified Data.Bencode.Encode as E
+
+main :: IO ()
+main =  defaultMain
+  [ bgroup "Decode"
+    [ envPure sData   $ bench "string" . whnf decString
+    , envPure iData   $ bench "integer" . whnf decInteger
+    , envPure lData   $ bench "list" . whnf decList
+    , envPure dData   $ bench "dict" . whnf decDict
+    , envPure sData   $ bench "text" . whnf decText
+    , envPure lsData  $ bench "list string" . whnf decListString
+    , envPure liData  $ bench "list int" . whnf decListInt
+    , envPure llData  $ bench "list list" . whnf decListList
+    , envPure ldData  $ bench "list dict" . whnf decListDict
+    , envPure ldData2 $ bench "list fields" . whnf decListFields
+    , envPure liData  $ bench "list word16" . whnf decListWord16
+    ]
+  , bgroup "Encode"
+    [ bench "string"      $ whnf encManyString n
+    , bench "integer"     $ whnf encManyInteger n
+    , bench "list"        $ whnf encManyList n100
+    , bench "list fusion" $ whnf encManyListFusion n
+    , bench "dict"        $ whnf encManyDict n100
+    , bench "text"        $ whnf encManyText n
+    , bench "int"         $ whnf encManyInt n
+    , bench "field"       $ whnf encManyField n10
+    , bench "word16"      $ whnf encManyWord16 n
+    ]
+  ]
+  where
+    -- How was the test data and size selected?
+    -- Pretty much arbitrarily. Sizes are chosen such that a benchmark
+    -- takes <= ~200ms.
+    n, n10, n100 :: Int
+    !n = 1000000
+    !n10 = n `div` 10
+    !n100 = n `div` 100
+
+    envPure = env . pure
+    toBS = BL.toStrict . BB.toLazyByteString
+
+    sData = BC.pack (show n) <> ":" <> stimes n "x"
+    iData = "i1" <> stimes n "1" <> "e"
+    lData = "l" <> stimes n "le" <> "e"
+    dData = toBS $ "d" <> go n10 <> "e"
+      where
+        go i | i == 2*n10 = mempty
+        go i = "6:" <> BB.intDec i <> "de" <> go (i+1)
+    lsData = toBS $ "l" <> stimes n10 s <> "e"
+      where
+        s = "5:hello5:world13:one two three"
+    liData = toBS $ "l" <> go n <> "e"
+      where
+        go 0 = mempty
+        go i = "i" <> BB.intDec (i .&. 0xffff) <> "e" <> go (i-1)
+    llData = toBS $ "l" <> stimes n "le" <> "e"
+    ldData = toBS $ "l" <> stimes n "de" <> "e"
+    ldData2 = toBS $ "l" <> stimes n10 d <> "e"
+      where
+        d = "d1:0de1:1de1:2de1:3de1:4de1:5de1:6de1:7de1:8de1:9dee"
+
+
+-- All bench functions below are marked NOINLINE to make it easy to find
+-- them by name in the GHC core output.
+
+------------------------------
+-- Decode
+------------------------------
+
+decString :: B.ByteString -> B.ByteString
+decString = runP D.string
+{-# NOINLINE decString #-}
+
+decInteger :: B.ByteString -> Integer
+decInteger = runP D.integer
+{-# NOINLINE decInteger #-}
+
+decList :: B.ByteString -> V.Vector (V.Vector ())
+decList = runP (D.list (D.list (pure ())))
+{-# NOINLINE decList #-}
+
+decDict :: B.ByteString -> M.Map B.ByteString (M.Map B.ByteString ())
+decDict = runP (D.dict (D.dict (pure ())))
+{-# NOINLINE decDict #-}
+
+decText :: B.ByteString -> T.Text
+decText = runP D.text
+{-# NOINLINE decText #-}
+
+decListString :: B.ByteString -> V.Vector B.ByteString
+decListString = runP (D.list D.string)
+{-# NOINLINE decListString #-}
+
+decListInt :: B.ByteString -> V.Vector Int
+decListInt = runP (D.list D.int)
+{-# NOINLINE decListInt #-}
+
+decListList :: B.ByteString -> V.Vector (V.Vector ())
+decListList = runP (D.list (D.list (pure ())))
+{-# NOINLINE decListList #-}
+
+decListDict :: B.ByteString -> V.Vector (M.Map B.ByteString ())
+decListDict = runP (D.list (D.dict (pure ())))
+{-# NOINLINE decListDict #-}
+
+decListFields :: B.ByteString -> V.Vector ()
+decListFields = runP (D.list foo)
+  where
+    foo = do
+      D.field "0" (pure ())
+      D.field "1" (pure ())
+      D.field "2" (pure ())
+      D.field "3" (pure ())
+      D.field "4" (pure ())
+      D.field "5" (pure ())
+      D.field "6" (pure ())
+      D.field "7" (pure ())
+      D.field "8" (pure ())
+      D.field "9" (pure ())
+{-# NOINLINE decListFields #-}
+
+decListWord16 :: B.ByteString -> V.Vector Word16
+decListWord16 = runP (D.list D.word16)
+{-# NOINLINE decListWord16 #-}
+
+runP :: D.Parser a -> B.ByteString -> a
+runP p = either error id . D.decode p
+{-# INLINE runP #-}
+
+------------------------------
+-- Encode
+------------------------------
+
+encManyString :: Int -> Int64
+encManyString = encMany E.string ("hello","world","one two three")
+{-# NOINLINE encManyString #-}
+
+encManyInteger :: Int -> Int64
+encManyInteger = encMany E.integer (0,-100000,fromIntegral (maxBound :: Int))
+{-# NOINLINE encManyInteger #-}
+
+encManyList :: Int -> Int64
+encManyList =
+  encMany (E.list (E.list E.value))
+          (V.empty, V.replicate 10 V.empty, V.replicate 90 V.empty)
+{-# NOINLINE encManyList #-}
+
+encManyListFusion :: Int -> Int64
+encManyListFusion = getL . E.toBuilder . E.list E.int . flip V.generate id
+{-# NOINLINE encManyListFusion #-}
+
+encManyDict :: Int -> Int64
+encManyDict =
+  encMany (E.dict (E.dict E.value))
+          (M.empty, M.singleton "a" M.empty, m99)
+{-# NOINLINE encManyDict #-}
+
+m99 :: M.Map B.ByteString (M.Map B.ByteString a)
+m99 = M.fromList [(BC.pack (show i), M.empty) | i <- [1..99 :: Int]]
+
+encManyText :: Int -> Int64
+encManyText = encMany E.text ("hello","world","one two three")
+{-# NOINLINE encManyText #-}
+
+encManyInt :: Int -> Int64
+encManyInt = encMany E.int (0,-100000,maxBound)
+{-# NOINLINE encManyInt #-}
+
+data ABC = A | B | C
+
+encManyField :: Int -> Int64
+encManyField = encMany foo (A,B,C)
+  where
+    foo A = e
+    foo B = E.dict' $ E.field "foo" id e
+    foo C = E.dict' $
+         E.field "0" id e
+      <> E.field "1" id e
+      <> E.field "2" id e
+      <> E.field "3" id e
+      <> E.field "4" id e
+      <> E.field "5" id e
+      <> E.field "6" id e
+      <> E.field "7" id e
+      <> E.field "8" id e
+      <> E.field "9" id e
+    e = E.dict id M.empty
+{-# NOINLINE encManyField #-}
+
+encManyWord16 :: Int -> Int64
+encManyWord16 = encMany E.word16 (0,1000,maxBound)
+{-# NOINLINE encManyWord16 #-}
+
+encMany :: (a -> E.Encoding) -> (a,a,a) -> Int -> Int64
+encMany enc (x0',x1',x2') = getL . go x0' x1' x2'
+  where
+    go _  _  _  0 = mempty
+    go x0 x1 x2 i = E.toBuilder (enc x0) <> go x1 x2 x0 (i-1)
+{-# INLINE encMany #-}
+
+getL :: BB.Builder -> Int64
+getL = BL.length . BB.toLazyByteString
+{-# INLINE getL #-}

--- a/src/Data/Bencode/AST.hs
+++ b/src/Data/Bencode/AST.hs
@@ -163,6 +163,7 @@ parseInteger s !pos = case BC.uncons s of
       Just (c,s'') -> case c of
         'e' -> Right (x, s'', pos'+1)
         _   -> errEnd (Just c) pos'
+    {-# INLINE end #-}
 {-# INLINE parseInteger #-}
 
 -- | Parse a Bencode string. From the length count to the end of the string.

--- a/src/Data/Bencode/Encode.hs
+++ b/src/Data/Bencode/Encode.hs
@@ -69,17 +69,20 @@ integer = integer_ BB.integerDec
 list :: (a -> Encoding) -> V.Vector a -> Encoding
 list enc vs =
   Encoding $ BB.char7 'l' <> foldMap (unEncoding . enc) vs <> BB.char7 'e'
+{-# INLINE list #-}
 
 -- | Encode a @Map@ as a Bencode dictionary, using the given encoder for values.
 dict :: (a -> Encoding) -> M.Map B.ByteString a -> Encoding
 dict enc kvs = Encoding $ BB.char7 'd' <> f kvs <> BB.char7 'e'
   where
     f = M.foldMapWithKey (\k v -> unEncoding (string k) <> unEncoding (enc v))
+{-# INLINE dict #-}
 
 -- | Encode @Text@ as a Bencode string. As per the Bencode specification, all
 -- text must be encoded as UTF-8 strings.
 text :: T.Text -> Encoding
 text = string . T.encodeUtf8
+{-# INLINE text #-}
 -- TODO: Check if Text's encodeUtf8Builder is more efficient. But we would
 -- also need to know the UTF-8 len, which is only viable for text >= 2.0.
 
@@ -102,6 +105,7 @@ field k enc v = FE (Endo ((k, enc v):))
 -- arbitrary key-value pair among them will be encoded and the rest discarded.
 dict' :: FieldEncodings -> Encoding
 dict' = dict id . M.fromList . ($ []) . appEndo . unFE
+{-# INLINE dict' #-}
 
 -- | Key-value encodings for a Bencode dictionary.
 newtype FieldEncodings = FE { unFE :: Endo [(B.ByteString, Encoding)] }


### PR DESCRIPTION
* Add benchmarks
* Inline functions where benchmarks show a clear decrease in time and allocations.

<details>
<summary>Benchmarks before, GHC 9.6.3 -O</summary>

```
All
  Decode
    string:      OK
      31.7 ns ± 1.9 ns, 191 B  allocated,   0 B  copied, 9.0 MB peak memory
    integer:     OK
      46.7 ms ± 4.7 ms,  27 MB allocated, 9.7 MB copied,  20 MB peak memory
    list:        OK
      175  ms ± 4.3 ms, 251 MB allocated, 248 MB copied, 138 MB peak memory
    dict:        OK
      29.4 ms ± 1.6 ms,  55 MB allocated,  42 MB copied, 138 MB peak memory
    text:        OK
      41.0 μs ± 2.7 μs, 975 KB allocated,  90 B  copied, 138 MB peak memory
    list string: OK
      38.4 ms ± 1.5 ms,  75 MB allocated,  57 MB copied, 138 MB peak memory
    list int:    OK
      220  ms ± 7.1 ms, 335 MB allocated, 302 MB copied, 237 MB peak memory
    list list:   OK
      141  ms ± 5.0 ms, 250 MB allocated, 206 MB copied, 237 MB peak memory
    list dict:   OK
      123  ms ± 2.7 ms, 244 MB allocated, 160 MB copied, 237 MB peak memory
    list fields: OK
      189  ms ± 6.6 ms, 358 MB allocated, 164 MB copied, 237 MB peak memory
    list word16: OK
      219  ms ±  14 ms, 351 MB allocated, 296 MB copied, 250 MB peak memory
  Encode
    string:      OK
      13.8 ms ± 733 μs, 101 MB allocated,  11 KB copied, 250 MB peak memory
    integer:     OK
      83.4 ms ± 3.2 ms, 368 MB allocated,  52 KB copied, 250 MB peak memory
    list:        OK
      28.1 ms ± 2.8 ms, 142 MB allocated,  26 KB copied, 250 MB peak memory
    list fusion: OK
      99.2 ms ± 6.6 ms, 236 MB allocated,  62 MB copied, 250 MB peak memory
    dict:        OK
      36.6 ms ± 2.2 ms, 169 MB allocated,  48 KB copied, 250 MB peak memory
    text:        OK
      73.3 ms ± 4.3 ms, 321 MB allocated,  42 KB copied, 250 MB peak memory
    int:         OK
      18.2 ms ± 1.4 ms,  33 MB allocated, 3.6 KB copied, 250 MB peak memory
    field:       OK
      31.2 ms ± 1.5 ms, 146 MB allocated,  20 KB copied, 250 MB peak memory
    word16:      OK
      8.43 ms ± 788 μs,  28 MB allocated, 3.0 KB copied, 250 MB peak memory
```
</details>

<details>
<summary>After</summary>

```
All
  Decode
    string:      OK
      25.8 ns ± 1.7 ns, 191 B  allocated,   0 B  copied, 9.0 MB peak memory, 18% less than baseline
    integer:     OK
      46.8 ms ± 2.1 ms,  28 MB allocated, 9.7 MB copied,  22 MB peak memory,       same as baseline
    list:        OK
      175  ms ± 6.6 ms, 251 MB allocated, 248 MB copied, 138 MB peak memory,       same as baseline
    dict:        OK
      29.5 ms ± 680 μs,  55 MB allocated,  42 MB copied, 138 MB peak memory,       same as baseline
    text:        OK
      40.6 μs ± 1.9 μs, 976 KB allocated,  89 B  copied, 138 MB peak memory,       same as baseline
    list string: OK
      38.9 ms ± 2.4 ms,  75 MB allocated,  57 MB copied, 138 MB peak memory,       same as baseline
    list int:    OK
      127  ms ± 3.8 ms, 190 MB allocated, 172 MB copied, 177 MB peak memory, 42% less than baseline
    list list:   OK
      146  ms ±  12 ms, 250 MB allocated, 206 MB copied, 177 MB peak memory,       same as baseline
    list dict:   OK
      125  ms ± 4.9 ms, 244 MB allocated, 160 MB copied, 177 MB peak memory,       same as baseline
    list fields: OK
      192  ms ± 6.2 ms, 358 MB allocated, 178 MB copied, 241 MB peak memory,       same as baseline
    list word16: OK
      143  ms ±  13 ms, 205 MB allocated, 191 MB copied, 241 MB peak memory, 34% less than baseline
  Encode
    string:      OK
      13.5 ms ± 742 μs, 101 MB allocated,  11 KB copied, 241 MB peak memory,       same as baseline
    integer:     OK
      83.5 ms ± 4.7 ms, 368 MB allocated,  52 KB copied, 241 MB peak memory,       same as baseline
    list:        OK
      22.1 ms ± 1.4 ms, 123 MB allocated,  23 KB copied, 241 MB peak memory, 21% less than baseline
    list fusion: OK
      9.16 ms ± 784 μs,  30 MB allocated, 3.3 KB copied, 241 MB peak memory, 90% less than baseline
    dict:        OK
      31.3 ms ± 1.8 ms, 139 MB allocated,  35 KB copied, 241 MB peak memory, 14% less than baseline
    text:        OK
      48.9 ms ± 3.4 ms, 276 MB allocated,  37 KB copied, 241 MB peak memory, 33% less than baseline
    int:         OK
      18.0 ms ± 1.4 ms,  33 MB allocated, 3.6 KB copied, 241 MB peak memory,       same as baseline
    field:       OK
      31.2 ms ± 1.6 ms, 143 MB allocated,  20 KB copied, 241 MB peak memory,       same as baseline
    word16:      OK
      8.30 ms ± 705 μs,  28 MB allocated, 2.9 KB copied, 241 MB peak memory,       same as baseline
```
</details>