### PR TITLE
Improve readKnownNaturalAs*

### DIFF
--- a/src/Data/Bencode/Util.hs
+++ b/src/Data/Bencode/Util.hs
@@ -9,6 +9,7 @@ import Data.Bits
 import Data.Int
 import Data.Word
 import qualified Data.ByteString as B
+import qualified Data.ByteString.Unsafe as B
 
 -- | The input string must be an unsigned decimal integer with no extraneous
 -- leading zeros. Returns Nothing if the value is outside the bounds of an
@@ -20,53 +21,64 @@ readKnownNaturalAsInt = readInt maxIntLen
       32 -> 10
       64 -> 19
       _  -> error "unsupported word size"
+{-# INLINE readKnownNaturalAsInt #-}
 
 -- | Similar to 'readKnownNaturalAsInt', for 'Int64'.
 readKnownNaturalAsInt64 :: Bool -> B.ByteString -> Maybe Int64
 readKnownNaturalAsInt64 = readInt 19
+{-# INLINE readKnownNaturalAsInt64 #-}
 
 readInt :: (Bounded a, Integral a) => Int -> Bool -> B.ByteString -> Maybe a
-readInt maxLen neg s = case B.uncons sr of
-  Nothing -> Just $! if neg then -n else n
-  Just (d,sr')
-    | B.null sr'
-    , let d' = fromIntegral d - 48
-    , n < iMaxDiv10 || n == iMaxDiv10 && d' <= (7 + fromIntegral (fromEnum neg))
-                       -- last digit of maxBound = 7, minBound = 8
-    -> Just $! if neg then -n * 10 - d' else n * 10 + d'
-    | otherwise -> Nothing
+readInt maxLen neg s = if neg then fmap negate n else n
   where
-    (sl,sr) = B.splitAt (maxLen - 1) s
-    n = B.foldl' (\acc d -> acc * 10 + fromIntegral d - 48) 0 sl
-    iMaxDiv10 = maxBound `div` 10
+    -- last digit of maxBound = 7, minBound = 8
+    n = readWord maxLen (maxBound `div` 10) (7 + fromIntegral (fromEnum neg)) s
 {-# INLINE readInt #-}
 
 -- | The input string must be an unsigned decimal integer with no extraneous
 -- leading zeros. Returns Nothing if the value is outside the bounds of a
 -- @Word@.
 readKnownNaturalAsWord :: B.ByteString -> Maybe Word
-readKnownNaturalAsWord = readWord maxWordLen
+readKnownNaturalAsWord = readWord maxWordLen (maxBound `div` 10) 5
   where
+    -- last digit of maxBound = 5
     maxWordLen = case finiteBitSize (0 :: Word) of
       32 -> 10
       64 -> 20
       _  -> error "unsupported word size"
+{-# INLINE readKnownNaturalAsWord #-}
 
 -- | Similar to 'readKnownNaturalAsWord', for 'Word64'.
 readKnownNaturalAsWord64 :: B.ByteString -> Maybe Word64
-readKnownNaturalAsWord64 = readWord 20
+readKnownNaturalAsWord64 = readWord 20 (maxBound `div` 10) 5
+{-# INLINE readKnownNaturalAsWord64 #-}
 
-readWord :: (Bounded a, Integral a) => Int -> B.ByteString -> Maybe a
-readWord maxLen s = case B.uncons sr of
-  Nothing -> Just $! n
-  Just (d,sr')
-    | B.null sr'
-    , let d' = fromIntegral d - 48
-    , n < wMaxDiv10 || n == wMaxDiv10 && d' <= 5 -- last digit of maxBound is 5
-    -> Just $! n * 10 + d'
-    | otherwise -> Nothing
-  where
-    (sl,sr) = B.splitAt (maxLen - 1) s
-    n = B.foldl' (\acc d -> acc * 10 + fromIntegral d - 48) 0 sl
-    wMaxDiv10 = maxBound `div` 10
+-- maxLen must be > 0!
+readWord :: (Bounded a, Integral a) => Int -> a -> a -> B.ByteString -> Maybe a
+readWord maxLen maxValueDiv10 maxValueMod10 s =
+  case compare (B.length s) maxLen of
+    LT -> Just $! readFull' s
+    EQ ->
+      let n = readFull (B.unsafeInit s)
+          d = digitToI (B.unsafeLast s)
+      in if n < maxValueDiv10 || n == maxValueDiv10 && d <= maxValueMod10
+         then Just $! n*10 + d
+         else Nothing
+    GT -> Nothing
 {-# INLINE readWord #-}
+
+readFull :: Integral a => B.ByteString -> a
+readFull = B.foldl' (\acc c -> acc * 10 + digitToI c) 0
+{-# INLINE readFull #-}
+
+-- Same as readFull but avoids
+-- https://gitlab.haskell.org/ghc/ghc/-/issues/24203
+readFull' :: Integral a => B.ByteString -> a
+readFull' s = case B.unsnoc s of
+  Nothing     -> 0
+  Just (s',c) -> readFull s' * 10 + digitToI c
+{-# INLINE readFull' #-}
+
+digitToI :: Integral a => Word8 -> a
+digitToI c = fromIntegral c - 48
+{-# INLINE digitToI #-}

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -276,5 +276,11 @@ instance Arbitrary Ben.Value where
         x <- choose (1,n)
         (x:) <$> partition (n-x)
 
+  shrink (Ben.String s)  = Ben.String <$> shrink s
+  shrink (Ben.Integer i) = Ben.Integer <$> shrink i
+  shrink (Ben.List xs)   = Ben.List . V.fromList <$> shrink (V.toList xs)
+  shrink (Ben.Dict kxs)  = Ben.Dict . M.fromList <$> shrink (M.toList kxs)
+
 instance Arbitrary B.ByteString where
   arbitrary = B.pack <$> arbitrary
+  shrink = map B.pack . shrink . B.unpack


### PR DESCRIPTION
Simpler implementation, reduced allocations, inlined.

<details>
<summary>Benchmarks, GHC 9.6.3 -O</summary>

```
All
  Decode
    dict:        OK
      29.6 ms ± 1.6 ms,  55 MB allocated,  42 MB copied, 138 MB peak memory
    list string: OK
      39.5 ms ± 2.7 ms,  75 MB allocated,  57 MB copied, 138 MB peak memory
    list int:    OK
      129  ms ± 6.6 ms, 190 MB allocated, 172 MB copied, 177 MB peak memory
    list fields: OK
      189  ms ±  16 ms, 358 MB allocated, 164 MB copied, 177 MB peak memory
    list word16: OK
      139  ms ±  14 ms, 205 MB allocated, 182 MB copied, 216 MB peak memory

All
  Decode
    dict:        OK
      27.5 ms ± 1.8 ms,  50 MB allocated,  40 MB copied, 138 MB peak memory,  7% less than baseline
    list string: OK
      40.3 ms ± 3.9 ms,  61 MB allocated,  57 MB copied, 138 MB peak memory,       same as baseline
    list int:    OK
      124  ms ± 3.8 ms, 145 MB allocated, 171 MB copied, 175 MB peak memory,       same as baseline
    list fields: OK
      178  ms ± 4.4 ms, 311 MB allocated, 164 MB copied, 175 MB peak memory,       same as baseline
    list word16: OK
      119  ms ± 2.6 ms, 145 MB allocated, 167 MB copied, 179 MB peak memory, 14% less than baseline
```
</details>